### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ListView折叠效果
 
-##Screenshots
+## Screenshots
 
 ![image](https://raw.githubusercontent.com/dodola/ListItemFold/master/screenshot/fold.gif)
 
@@ -10,7 +10,7 @@ ListView折叠效果
 
 
 
-##License
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
